### PR TITLE
38 streamline manager naming

### DIFF
--- a/ESP32/lib/memory/flash_manager.cpp
+++ b/ESP32/lib/memory/flash_manager.cpp
@@ -1,10 +1,10 @@
-#include "flash_controller.h"
+#include "flash_manager.h"
 
-Flash_controller::Flash_controller() : m_tag("flash_controller") {}
+Flash_manager::Flash_manager() : m_tag("flash_manager") {}
 
-Flash_controller::~Flash_controller() = default;
+Flash_manager::~Flash_manager() = default;
 
-esp_err_t Flash_controller::init() {
+esp_err_t Flash_manager::init() {
   esp_err_t ret = nvs_flash_init();
   if (ret == ESP_ERR_NVS_NO_FREE_PAGES ||
       ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {

--- a/ESP32/lib/memory/flash_manager.h
+++ b/ESP32/lib/memory/flash_manager.h
@@ -1,5 +1,5 @@
-#ifndef FLASH_CONTROLLER_H
-#define FLASH_CONTROLLER_H
+#ifndef FLASH_MANAGER_H
+#define FLASH_MANAGER_H
 
 #pragma once
 
@@ -8,10 +8,10 @@
 
 #include "nvs_flash.h"
 
-class Flash_controller {
+class Flash_manager {
  public:
-  Flash_controller();
-  ~Flash_controller();
+  Flash_manager();
+  ~Flash_manager();
 
   esp_err_t init();
 

--- a/ESP32/lib/memory/flash_manager.h
+++ b/ESP32/lib/memory/flash_manager.h
@@ -19,4 +19,4 @@ class Flash_manager {
   const std::string m_tag;
 };
 
-#endif  // FLASH_CONTROLLER_H
+#endif  // FLASH_MANAGER_H

--- a/ESP32/lib/wifi/wifi_manager.h
+++ b/ESP32/lib/wifi/wifi_manager.h
@@ -69,4 +69,4 @@ class Wifi_manager {
   esp_netif_t *m_wifi_netif = NULL;
 };
 
-#endif  // WIFI_HANDLER_H
+#endif  // WIFI_MANAGER_H

--- a/ESP32/lib/wifi/wifi_manager.h
+++ b/ESP32/lib/wifi/wifi_manager.h
@@ -1,5 +1,5 @@
-#ifndef WIFI_HANDLER_H
-#define WIFI_HANDLER_H
+#ifndef WIFI_MANAGER_H
+#define WIFI_MANAGER_H
 
 #pragma once
 
@@ -21,10 +21,10 @@
 static uint8_t channel_list[CHANNEL_LIST_SIZE] = {1, 6, 11};
 #endif
 
-class Wifi_handler {
+class Wifi_manager {
  public:
-  Wifi_handler();
-  ~Wifi_handler();
+  Wifi_manager();
+  ~Wifi_manager();
 
   void event_handler(void *event_handler_arg, const esp_event_base_t event_base,
                      const int32_t event_id, const void *event_data);
@@ -61,7 +61,7 @@ class Wifi_handler {
                                    const int32_t event_id, void *event_data);
 
  private:
-  const std::string m_tag = "wifi_handler";
+  const std::string m_tag = "wifi_manager";
   std::string m_ssid = "";
   std::string m_password = "";
   uint8_t m_retry_num = 0;

--- a/ESP32/src/main.cpp
+++ b/ESP32/src/main.cpp
@@ -16,22 +16,22 @@
 // source files
 #include "flash_manager.h"
 #include "sntp_service.h"
-// #include "uart_handler.h"
 #include "wifi_manager.h"
 
 #define READ_PRIORITY (configMAX_PRIORITIES - 1)
 
 static const char *TAG = "app_main";
 
-// uart_handler uart_handler_;
 Wifi_manager wifi_manager;
 Sntp_service sntp;
 
-static void read_uart_task(void *arg) {
+// TODO: enable when implemented
+/*static void read_uart_task(void *arg) {
   while (1) {
-    // uart_handler_.read_from_sensor();
+    // read from RP2040
   }
 }
+*/
 
 static void print_test_task(void *arg) {
   while (1) {
@@ -73,10 +73,4 @@ extern "C" void app_main() {
 
   // start SNTP service
   ESP_ERROR_CHECK(sntp.init());
-
-  // uart_handler_.init_uart();
-
-  // xTaskCreate(read_uart_task, "read_uart_task", 1024 * 6, NULL,
-  // READ_PRIORITY, NULL);
-  // lv_label_set_text_fmt(ui_temperatureLabel, "%.1f°C", 20.5);
 }

--- a/ESP32/src/main.cpp
+++ b/ESP32/src/main.cpp
@@ -14,22 +14,22 @@
 #endif
 #endif
 // source files
-#include "flash_controller.h"
+#include "flash_manager.h"
 #include "sntp_service.h"
-//#include "uart_handler.h"
-#include "wifi_handler.h"
+// #include "uart_handler.h"
+#include "wifi_manager.h"
 
 #define READ_PRIORITY (configMAX_PRIORITIES - 1)
 
 static const char *TAG = "app_main";
 
-//uart_handler uart_handler_;
-Wifi_handler wifi_handler;
+// uart_handler uart_handler_;
+Wifi_manager wifi_manager;
 Sntp_service sntp;
 
 static void read_uart_task(void *arg) {
   while (1) {
-    //uart_handler_.read_from_sensor();
+    // uart_handler_.read_from_sensor();
   }
 }
 
@@ -42,18 +42,18 @@ static void print_test_task(void *arg) {
 
 void scan_wifi() {
   std::array<wifi_ap_record_t, (size_t)DEFAULT_SCAN_LIST_SIZE> scan_res;
-  while (wifi_handler.scan(scan_res) != ESP_OK) {
+  while (wifi_manager.scan(scan_res) != ESP_OK) {
     ESP_LOGI(TAG, "Scan failed. Wait and try again");
     vTaskDelay(1000 / portTICK_PERIOD_MS);  // 1 s delay
   };
-  wifi_handler.log_ap_info(scan_res);
+  wifi_manager.log_ap_info(scan_res);
 }
 
 extern "C" void app_main() {
   ESP_ERROR_CHECK(bsp_board_init());
 
   // init internal Flash
-  Flash_controller memory;
+  Flash_manager memory;
   memory.init();
 
   // init display functionality
@@ -64,9 +64,12 @@ extern "C" void app_main() {
   ESP_ERROR_CHECK(esp_event_loop_create_default());
 
   // init WIFI and esablish a connection to the AP set in the credentials
-  ESP_ERROR_CHECK(wifi_handler.init_sta());
-  ESP_ERROR_CHECK(wifi_handler.connect_to_wifi());
-  //ESP_LOGI(TAG, "SSID: %s", INIT_WIFI_SSID);
+  ESP_ERROR_CHECK(wifi_manager.init_sta());
+#if defined INIT_WIFI_SSID && defined INIT_WIFI_PASSWORD
+  ESP_ERROR_CHECK(
+      wifi_manager.set_ssid_and_pw(INIT_WIFI_SSID, INIT_WIFI_PASSWORD));
+  ESP_ERROR_CHECK(wifi_manager.connect_to_wifi());
+#endif
 
   // start SNTP service
   ESP_ERROR_CHECK(sntp.init());

--- a/ESP32/test/test_embedded/test_main.cpp
+++ b/ESP32/test/test_embedded/test_main.cpp
@@ -5,12 +5,10 @@
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-// soure libaries
+// source libaries
 #include "flash_manager.h"
 // test libaries
 #include "test_wifi.h"
-// TEST(...)
-// TEST_F(...)
 
 static const char *TAG = "test_app_main";
 
@@ -29,6 +27,4 @@ extern "C" void app_main() {
   //
   if (RUN_ALL_TESTS()) {
   }
-
-  // test_wifi(0, NULL);
 }

--- a/ESP32/test/test_embedded/test_main.cpp
+++ b/ESP32/test/test_embedded/test_main.cpp
@@ -6,7 +6,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 // soure libaries
-#include "flash_controller.h"
+#include "flash_manager.h"
 // test libaries
 #include "test_wifi.h"
 // TEST(...)
@@ -22,7 +22,7 @@ extern "C" void app_main() {
       "*";  // e.g.: "DummyTest.ShouldPass", default = "*"
   ::testing::InitGoogleTest();
   ESP_ERROR_CHECK(bsp_board_init());
-  Flash_controller memory;
+  Flash_manager memory;
   memory.init();
   // create default event loop for wifi
   ESP_ERROR_CHECK(esp_event_loop_create_default());

--- a/ESP32/test/test_embedded/test_sntp.cpp
+++ b/ESP32/test/test_embedded/test_sntp.cpp
@@ -14,7 +14,7 @@ TEST_F(WifiTest, Sntp) {
   sntp_sync_status_t sntp_status;
   Sntp_service sntp;
 
-  EXPECT_EQ(m_wifi_handler.connect_to_wifi(), ESP_OK)
+  EXPECT_EQ(m_wifi_manager.connect_to_wifi(), ESP_OK)
       << "Wifi connection could not be established";
 
   std::tm build_time_tm{};

--- a/ESP32/test/test_embedded/test_wifi.cpp
+++ b/ESP32/test/test_embedded/test_wifi.cpp
@@ -3,12 +3,12 @@
 // void test_wifi_default_connection(void) {
 TEST_F(WifiTest, DefaultConnectionEstablish) {
   // connect to wifi defined in the credentials
-  EXPECT_EQ(m_wifi_handler.connect_to_wifi(), ESP_OK)
+  EXPECT_EQ(m_wifi_manager.connect_to_wifi(), ESP_OK)
       << "Wifi connection could not be established";
 }
 
 TEST_F(WifiTest, Scan) {
-  EXPECT_EQ(m_wifi_handler.connect_to_wifi(), ESP_OK)
+  EXPECT_EQ(m_wifi_manager.connect_to_wifi(), ESP_OK)
       << "Wifi connection could not be established";
 
   int max_tries = 10;
@@ -16,7 +16,7 @@ TEST_F(WifiTest, Scan) {
 
   // create ap_records array in which the scan result is saved
   std::array<wifi_ap_record_t, (size_t)DEFAULT_SCAN_LIST_SIZE> scan_res;
-  while (m_wifi_handler.scan(scan_res) != ESP_OK) {
+  while (m_wifi_manager.scan(scan_res) != ESP_OK) {
     current_try++;
     ASSERT_LT(current_try, max_tries);
     std::cout << "Scan failed. Wait and try again" << std::endl;
@@ -24,7 +24,7 @@ TEST_F(WifiTest, Scan) {
   };
 
   // print scan result
-  m_wifi_handler.log_ap_info(scan_res);
+  m_wifi_manager.log_ap_info(scan_res);
 
   // get connected AP and check if it is in the scan result
   wifi_ap_record_t connected_ap_info;

--- a/ESP32/test/test_embedded/test_wifi.h
+++ b/ESP32/test/test_embedded/test_wifi.h
@@ -6,8 +6,8 @@
 #include "gtest/gtest.h"
 
 //
-#include "flash_controller.h"
-#include "wifi_handler.h"
+#include "flash_manager.h"
+#include "wifi_manager.h"
 
 int test_wifi(int argc, char **argv);
 
@@ -24,7 +24,7 @@ class WifiTest : public testing::Test {
   void SetUp() override {
     // Code here will be called immediately after the constructor (right
     // before each test).
-    m_wifi_handler.init_sta();
+    m_wifi_manager.init_sta();
   }
 
   void TearDown() override {
@@ -36,7 +36,7 @@ class WifiTest : public testing::Test {
   }
   // variables
   //  init with default constructor
-  Wifi_handler m_wifi_handler;
+  Wifi_manager m_wifi_manager;
 };
 
 #endif  // TEST_WIFI_H


### PR DESCRIPTION
To streamline the naming of classes, files, and components that independently handle a specific aspect of the code, they are suffixed with ` _manager`. This improves clarity and makes understanding responsibilities easier.

Closes #38
